### PR TITLE
(maint) - Remove redundant parenthesis check

### DIFF
--- a/lib/puppet-lint/plugins/stdlib_deprecated_functions.rb
+++ b/lib/puppet-lint/plugins/stdlib_deprecated_functions.rb
@@ -33,8 +33,6 @@ NAMESPACED_FUNCTIONS = %w[
 PuppetLint.new_check(:stdlib_deprecated_functions) do
   def check
     tokens.select { |x| DEPRECATED_FUNCTIONS_VAR_TYPES.include?(x.type) }.each do |token|
-      next unless token.next_code_token.type == :LPAREN # Skip if it's not a function call
-
       if REMOVED_FUNCTIONS.include?(token.value)
         removed_function_detected = true
       elsif NAMESPACED_FUNCTIONS.include?(token.value)


### PR DESCRIPTION
Removes a redundant check for opening parenthesis to symbolise function call.
As per http://puppet-lint.com/developer/tokens/
`
A special case for the :NAME token where the value is suffixed with a left parentheses (e.g. hiera(, template()
`