### PR TITLE
(CAT-2020) Update repo to reflect renaming of tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# puppet-lint-stdlib_deprecated_functions
-A puppet-lint plugin to detect deprecated, removed and non-namespaced puppetlabs-stdlib functions.
+# puppet-lint-stdlib_deprecations
+A puppet-lint plugin to detect puppetlabs-stdlib deprecations including removed and non-namespaced functions and datatypes.

--- a/lib/puppet-lint/plugins/version.rb
+++ b/lib/puppet-lint/plugins/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class StdlibDeprecatedFunctions
+class StdlibDeprecations
   VERSION ||= '0.0.1'
 end

--- a/puppet-lint-stdlib_deprecations.gemspec
+++ b/puppet-lint-stdlib_deprecations.gemspec
@@ -5,8 +5,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'puppet-lint/plugins/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'puppet-lint-stdlib_deprecated_functions'
-  spec.version       = StdlibDeprecatedFunctions::VERSION
+  spec.name          = 'puppet-lint-stdlib_deprecations'
+  spec.version       = StdlibDeprecations::VERSION
   spec.authors       = ['Puppet, Inc.']
   spec.files         = Dir[
     'README.md',
@@ -16,10 +16,10 @@ Gem::Specification.new do |spec|
   ]
   spec.summary       = 'A puppet-lint plugin to aid your puppetlabs-stdlib 9.x upgrade.'
   spec.description   = <<-DESC
-    Helps to detect deprecated, removed and non-namespaced puppetlabs-stdlib functions during your upgrade to puppetlabs-stdlib 9.x,
+    Helps to detect deprecated, removed and non-namespaced puppetlabs-stdlib functions and datatypes during your upgrade to puppetlabs-stdlib 9.x,
     and puppet 8.
   DESC
-  spec.homepage      = 'https://github.com/puppetlabs/puppet-lint-stdlib_deprecated_functions'
+  spec.homepage      = 'https://github.com/puppetlabs/puppet-lint-stdlib_deprecations'
   spec.license       = 'Apache-2.0'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.7')
 


### PR DESCRIPTION
Recently the tool was renamed from `puppet-lint-stdlib_deprecated_functions` to `puppet-lint-stdlib_deprecations`. This commit updates various files to reflect the new name and maintain consistency.