### PR TITLE
(bug) - Corrects suggestion for has_key method

### DIFF
--- a/lib/puppet-lint/plugins/stdlib_deprecated_functions.rb
+++ b/lib/puppet-lint/plugins/stdlib_deprecated_functions.rb
@@ -19,7 +19,7 @@ REPLACED_FUNCTIONS = {
   'size' => 'length()',
   'sprintf_hash' => 'sprintf()',
   'hash' => 'Puppets built-in Hash.new()',
-  'has_key' => 'appropriate Puppet match expressions'
+  'has_key' => '"if \'key\' in $my_hash"'
 }.freeze
 
 # These functions have been namespaced in stdlib 9.x.


### PR DESCRIPTION
This commit corrects an issue where the suggested replacement for the has_key funciton was to use puppet lang matchers. This is not a suitable replacement, and instead should use puppets 'if "key" in $my_hash' expression instead.

Additional context:
https://github.com/puppetlabs/puppetlabs-stdlib/pull/1319